### PR TITLE
place wraper at same position as element

### DIFF
--- a/lib/effect.dart
+++ b/lib/effect.dart
@@ -33,9 +33,9 @@ Element _createWrapper(Element element) {
 
   var parent = element.parent;
 
+  int index = parent.children.indexOf(element);
   wrapper.children.add(element);
-
-  parent.children.add(wrapper);
+  parent.children.insert(index, wrapper);
 
   return wrapper;
 }


### PR DESCRIPTION
The wrapper element for effects is now added with the same index as the element had before in order to maintain the position in the layout.
